### PR TITLE
support for inclusive namespaces with xml-crypto

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -1,3 +1,4 @@
+
 var zlib = require('zlib');
 var xml2js = require('xml2js');
 var xmlCrypto = require('xml-crypto');
@@ -466,8 +467,9 @@ SAML.prototype.validateSignature = function (fullXml, currentNode, cert) {
   var signatures = xpath(currentNode, xpathSigQuery);
   // This function is expecting to validate exactly one signature, so if we find more or fewer
   //   than that, reject.
-  if (signatures.length != 1)
+  if (signatures.length != 1) {
     return false;
+  }
   var signature = signatures[0];
   var sig = new xmlCrypto.SignedXml();
   sig.keyInfoProvider = {
@@ -481,26 +483,93 @@ SAML.prototype.validateSignature = function (fullXml, currentNode, cert) {
   sig.loadSignature(signature);
   // We expect each signature to contain exactly one reference to the top level of the xml we
   //   are validating, so if we see anything else, reject.
-  if (sig.references.length != 1 )
+  if (sig.references.length != 1 ) {
     return false;
+  }
   var refUri = sig.references[0].uri;
   var refId = (refUri[0] === '#') ? refUri.substring(1) : refUri;
   // If we can't find the reference at the top level, reject
   var idAttribute = currentNode.getAttribute('ID') ? 'ID' : 'Id';
-  if (currentNode.getAttribute(idAttribute) != refId)
+  if (currentNode.getAttribute(idAttribute) != refId) {
     return false;
+  }
   // If we find any extra referenced nodes, reject.  (xml-crypto only verifies one digest, so
   //   multiple candidate references is bad news)
   var totalReferencedNodes = xpath(currentNode.ownerDocument,
                                   "//*[@" + idAttribute + "='" + refId + "']");
-  if (totalReferencedNodes.length > 1)
+  if (totalReferencedNodes.length > 1) {
     return false;
-  return sig.checkSignature(fullXml);
+  }
+  var res = sig.checkSignature(fullXml);
+  return res;
 };
+
+/**
+ * Takes in a SAML response XML string and applies inclusive
+ * namespaces to the Assertion tag if the namespaces are defined on the root
+ * document tag. Workaround for xml-crypto lib issue
+ * see https://github.com/yaronn/xml-crypto/issues/48#issuecomment-129705816
+ * @param {String} xml
+ * @return {String} xml with namespace definitions on Assertion tag
+ */
+function addNamespacesToAssertion(xml) {
+  var xmlns_exc_c14n_definition = 'http://www.w3.org/2001/10/xml-exc-c14n#';
+  var xmlns_samlp = 'urn:oasis:names:tc:SAML:2.0:protocol';
+  var xmlns_saml = 'urn:oasis:names:tc:SAML:2.0:assertion';
+
+  var doc = new xmldom.DOMParser().parseFromString(xml);
+  var responses = doc.getElementsByTagNameNS(xmlns_samlp, 'Response');
+
+  if (responses.length !== 1) {
+    throw new Error('passport-saml saml.js addNamespacesToAssertion cannot find saml response');
+  }
+
+  var response = responses[0];
+
+
+  var assertions = xpath(doc, "/*[local-name()='Response']/*[local-name()='Assertion']");
+  // Assume only 1 assertion
+  if (assertions.length !== 1) {
+    throw new Error('passport-saml sam.js addNamespacesToAssertion found multiple assertions');
+  }
+
+  var assertion = assertions[0];
+  var namespaces = assertion.getElementsByTagNameNS(xmlns_exc_c14n_definition, 'InclusiveNamespaces');
+
+  // There may be no namespacing, carry on with original xml
+  if (namespaces.length !== 1) {
+    return xml;
+  }
+
+  var inclusiveNamespaces = namespaces[0];
+  var prefixList = inclusiveNamespaces.getAttribute('PrefixList');
+
+  var prefixListVals = prefixList.split(' ');
+
+  for (index in prefixListVals) {
+    var ns = 'xmlns:' + prefixListVals[index];
+    var nsAttributeVal = response.getAttribute(ns);
+    if (nsAttributeVal && !assertion.getAttribute(ns)) {
+      // namespace definition is on the parent response, not the assertion,
+      // so now we'll add it to the assertion
+      var newNSAttribute = doc.createAttribute(ns);
+      newNSAttribute.value = nsAttributeVal;
+      assertion.setAttributeNode(newNSAttribute);
+    }
+  }
+
+  // Turn any modifications back into a string
+  return new xmldom.XMLSerializer().serializeToString(response);
+
+}
 
 SAML.prototype.validatePostResponse = function (container, callback) {
   var self = this;
+
   var xml = new Buffer(container.SAMLResponse, 'base64').toString('utf8');
+
+  xml = addNamespacesToAssertion(xml);
+
   var doc = new xmldom.DOMParser().parseFromString(xml);
 
   var inResponseTo = xpath(doc, "/*[local-name()='Response']/@InResponseTo");


### PR DESCRIPTION
parses namespace values from SAML Response that are not on the Assertion. Applies ns values to the assertion in order to generate correct canonical xml so signature validation performs as expected.

Needs tests.